### PR TITLE
Enable susy support via node-sass/gulp-sass upgrade

### DIFF
--- a/app/prompts.json
+++ b/app/prompts.json
@@ -278,7 +278,7 @@
           "key": "node-sass",
           "extension": "scss",
           "module": "gulp-sass",
-          "version": "~1.1.0"
+          "version": "~1.3.0"
         },
         "name": "Sass (Node), Node.js binding to libsass, the C version of the popular stylesheet preprocessor, Sass."
       },


### PR DESCRIPTION
Susy requires map support which isn't available/specified in upstream dependencies until node-sass gulp-sass 1.3.1. Gulp-sass is really just a wrapper of node-sass and pulls in a specified version in package.json.

Trivial patch of the month club here but this will help a lot of people looking to get up and running on more advanced sass functionality that is leveraged by systems like susy.
